### PR TITLE
Added theme options for social links and footer menu.

### DIFF
--- a/assets/scss/foundation.scss
+++ b/assets/scss/foundation.scss
@@ -91,3 +91,6 @@
 // Templates
 @import "templates/front";
 @import "templates/kitchen-sink";
+
+// Custom
+@import "site/tvh";

--- a/assets/scss/site/tvh.scss
+++ b/assets/scss/site/tvh.scss
@@ -1,0 +1,40 @@
+//Colors
+$orange: #db6829;
+
+
+//Footer Social Links
+.footer-social-link {
+	display: inline-block; 
+	
+	& a { 
+		color: $orange;
+	    display: block;
+	    //float: left;
+	    width: 2.375rem;
+	    height: 2.375rem;
+	    border: 2px solid $orange;
+	    border-radius: 20px;
+	    margin: .625rem;
+	    position: relative;
+	}
+
+	& a i {
+	    font-size: 1.25rem;
+	    color: $orange;
+	    position: absolute;
+	    top: 50%;
+	    left: 50%;
+	    transform: translate(-50%, -50%);
+	}
+}
+
+//Footer Navigation
+#tvh-footer-menu li { 
+	display: inline-block; 
+	& a { color: $orange; }
+	& a:after { 
+		content: '|';
+		padding: 0rem 1rem; 
+	}
+	&:last-child a:after { content: ''; }
+}

--- a/footer.php
+++ b/footer.php
@@ -14,6 +14,63 @@
 				<?php do_action( 'foundationpress_before_footer' ); ?>
 				<?php dynamic_sidebar( 'footer-widgets' ); ?><em>SOCIAL MEDIA AS WIDGET CONTENT</em><br>
 				<?php do_action( 'foundationpress_after_footer' ); ?><em>NAVIGATION AS WIDGET CONTENT</em>
+
+				<!-- Social Links -->
+				<?php 
+
+					//Get Custom Theme Options
+					$options = get_option('tvh_theme_options');
+
+					//If we have facebook data add icon
+					if ( $options['tvh_fb_textbox'] != null || $options['tvh_fb_textbox'] != "" ) : ?>
+						<div id="footer-social-container">
+							<div class="footer-social-link">
+								<a href="<?php echo $options['tvh_fb_textbox']; ?>" title="The Villages Health Facebook" target="_blank"><i class="fa fa-facebook" aria-hidden="true"></i></a>
+							</div>
+					<?php endif; 
+
+					//If we have twitter data add icon
+					if ( $options['tvh_twitter_textbox'] != null || $options['tvh_twitter_textbox'] != "") : ?>
+							<div class="footer-social-link">
+								<a href="<?php echo $options['tvh_twitter_textbox']; ?>" title="The Villages Health Twitter" target="_blank"><i class="fa fa-twitter" aria-hidden="true"></i></a>
+							</div>
+					<?php endif; 
+
+					//If we have YouTube data dd icon
+					if ( $options['tvh_youtube_textbox'] != null || $options['tvh_youtube_textbox'] != "") : ?>
+							<div class="footer-social-link">
+								<a href="<?php echo $options['tvh_youtube_textbox']; ?>" title="The Villages Health YouTube" target="_blank"><i class="fa fa-youtube" aria-hidden="true"></i></a>
+							</div>
+						</div>
+					<?php endif; 
+				?>
+				<!-- /Social Links -->
+
+
+				<!-- Footer Navigation -->
+				<?php 
+
+					$args = array(
+						'theme_location'  => 'tvh_footer_menu',
+						'menu'            => '',
+						'container'       => 'div',
+						'container_class' => 'menu-{menu slug}-container',
+						'container_id'    => '',
+						'menu_class'      => 'tvh-footer-menu',
+						'menu_id'         => 'tvh-footer-menu',
+						'echo'            => true,
+						'fallback_cb'     => 'wp_page_menu',
+						'before'          => '',
+						'after'           => '',
+						'link_before'     => '',
+						'link_after'      => '',
+						'items_wrap'      => '<ul id="%1$s" class="%2$s">%3$s</ul>',
+						'depth'           => 0,
+						'walker'          => ''
+					);
+					wp_nav_menu( $args );
+
+				?>
 				<p class="foot-copyright">&copy; Holding Company of The Villages, Inc., <?php echo date('Y'); ?> All Rights Reserved. The Villages is a registered trademark of Holding Company of The Villages, Inc.</p>
 			</footer>
 		</div>

--- a/functions.php
+++ b/functions.php
@@ -53,3 +53,152 @@ require_once( 'library/responsive-images.php' );
 
 /** If your site requires protocol relative url's for theme assets, uncomment the line below */
 // require_once( 'library/class-foundationpress-protocol-relative-theme-assets.php' );
+
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Add Menu
+ * ------------------------------------------------------------------------ */
+function tvh_theme_menu()
+{
+	//add_theme_page( $page_title, $menu_title, $capability, $menu_slug, $function );
+ 	add_theme_page( 'Theme Option', 'Theme Options', 'manage_options', 'tvh-theme-options', 'tvh_theme_page');  
+}
+add_action('admin_menu', 'tvh_theme_menu');
+
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Add Content to Theme Options Page
+ * ------------------------------------------------------------------------ */
+function tvh_theme_page()
+{
+
+echo '<div class="wrap">
+		<div id="icon-options-general" class="icon32"></div>
+			<h1>The Villages Health: Theme Options</h1>
+			<div id="poststuff">
+				<div id="post-body" class="metabox-holder columns-1">
+				<div id="post-body-content">
+					<div class="meta-box-sortables ui-sortable">
+						<div class="postbox">
+							<div class="inside">
+								<div class="section-panel">
+									<h1></h1>
+									<form method="post" enctype="multipart/form-data" action="options.php">';
+									settings_fields('tvh_theme_options'); 
+									do_settings_sections('tvh_theme_options.php');
+									echo '<p class="submit">
+									<input type="submit" class="button-primary" value="Save Changes" />
+									</p>
+									</form>
+								</div>
+								<p></p>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+</div> ';
+
+}
+       
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Register Settings
+ * ------------------------------------------------------------------------ */
+
+function tvh_register_settings()
+{
+    // Register the settings with Validation callback
+    register_setting( 'tvh_theme_options', 'tvh_theme_options', 'tvh_validate_settings' );
+
+    // Add settings section
+    add_settings_section( 'tvh_text_section', '', 'tvh_display_section', 'tvh_theme_options.php' );
+
+    //Facebook Link Args
+    $fb_args = array(
+      'type'      => 'text',
+      'id'        => 'tvh_fb_textbox',
+      'name'      => 'tvh_fb_textbox',
+      'desc'      => '',
+      'std'       => '',
+      'label_for' => 'tvh_fb_textbox',
+      'class'     => 'css_class'
+    );
+
+    $twitter_args = array(
+      'type'      => 'text',
+      'id'        => 'tvh_twitter_textbox',
+      'name'      => 'tvh_twitter_textbox',
+      'desc'      => '',
+      'std'       => '',
+      'label_for' => 'tvh_twitter_textbox',
+      'class'     => 'css_class'
+    );
+
+    $youtube_args = array(
+      'type'      => 'text',
+      'id'        => 'tvh_youtube_textbox',
+      'name'      => 'tvh_youtube_textbox',
+      'desc'      => '',
+      'std'       => '',
+      'label_for' => 'tvh_youtube_textbox',
+      'class'     => 'css_class'
+    );
+
+    add_settings_field( 'tvh_fb_link', 'Facebook Link:', 'tvh_display_setting', 'tvh_theme_options.php', 'tvh_text_section', $fb_args );
+    add_settings_field( 'tvh_twitter_link', 'Twitter Link:', 'tvh_display_setting', 'tvh_theme_options.php', 'tvh_text_section', $twitter_args );
+    add_settings_field( 'tvh_youtube_link', 'YouTube Link:', 'tvh_display_setting', 'tvh_theme_options.php', 'tvh_text_section', $youtube_args );
+}
+add_action( 'admin_init', 'tvh_register_settings' );
+
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Displays Theme Sections
+ * ------------------------------------------------------------------------ */
+function tvh_display_section($section){ 
+
+}
+
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Display Settings
+ * ------------------------------------------------------------------------ */
+function tvh_display_setting($args)
+{
+    extract( $args );
+
+    $option_name = 'tvh_theme_options';
+
+    $options = get_option( $option_name );
+
+    switch ( $type ) {  
+          case 'text':  
+              $options[$id] = stripslashes($options[$id]);  
+              $options[$id] = esc_attr( $options[$id]);  
+              echo "<input class='regular-text$class' type='text' id='$id' name='" . $option_name . "[$id]' value='$options[$id]' />";
+              echo ($desc != '') ? "<br /><span class='description'>$desc</span>" : "";  
+          break;  
+    }
+}
+
+/* ------------------------------------------------------------------------ *
+ * Theme Options - Validate Settings
+ * ------------------------------------------------------------------------ */
+function tvh_validate_settings($input)
+{
+  foreach($input as $k => $v)
+  {
+    $newinput[$k] = trim($v);
+    
+    // Check the input is a letter or a number
+    // if(!preg_match('/^[A-Z0-9 _]*$/i', $v)) {
+    //   $newinput[$k] = '';
+    // }
+  }
+
+  return $newinput;
+}
+
+/* ------------------------------------------------------------------------ *
+ * Menus - Footer Menu
+ * ------------------------------------------------------------------------ */
+register_nav_menus( array(
+  'tvh_footer_menu' => 'Footer Menu',
+) );

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -14,7 +14,7 @@ var cleanCSS    = require('gulp-clean-css');
 
 // Enter URL of your local server here
 // Example: 'http://localwebsite.dev'
-var URL = 'http://localhost/tvh';
+var URL = 'http://localhost/tvh-website-2017';
 
 // Check for --production flag
 var isProduction = !!(argv.production);


### PR DESCRIPTION
@eddt 

This adds a "theme options" page under the appearance menu in the backend of WP for social links (and whatever else we want to use it for). I also added the social links to the footer and added the footer navigation. I did not get around to looking at the rows/columns for these pieces. The themes option page was mainly for my own experimenting but I think its a nice touch and will be something we can continue using. 